### PR TITLE
fix the maximum number of volumes for KVM instances.

### DIFF
--- a/pkg/evs/nodeserver.go
+++ b/pkg/evs/nodeserver.go
@@ -24,6 +24,10 @@ import (
 	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/utils/mounts"
 )
 
+const (
+	maxVolumes = 24 // the maximum number of volumes for a KVM instance is 24
+)
+
 type nodeServer struct {
 	Driver   *EvsDriver
 	Mount    mounts.IMount
@@ -303,7 +307,7 @@ func (ns *nodeServer) NodeGetInfo(_ context.Context, req *csi.NodeGetInfoRequest
 	return &csi.NodeGetInfoResponse{
 		NodeId:             nodeID,
 		AccessibleTopology: topology,
-		MaxVolumesPerNode:  16,
+		MaxVolumesPerNode:  maxVolumes,
 	}, nil
 }
 


### PR DESCRIPTION
The maximum number of volumes mounted on a KVM instance by querying data is 24, so fix it.