### PR TITLE
fix: the device path should be taken from the node(ESC)

### DIFF
--- a/cmd/evs-csi-plugin/main.go
+++ b/cmd/evs-csi-plugin/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/version"
 	"os"
+
+	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -102,7 +103,7 @@ func main() {
 func handle() {
 	cloud, err := config.LoadConfig(cloudConfig)
 	if err != nil {
-		klog.Errorf("Failed to load cloud config: %v", err)
+		klog.Fatalf("Failed to load cloud config: %v", err)
 	}
 
 	d := evs.NewDriver(cloud, endpoint, cluster, nodeID)

--- a/pkg/evs/services/volumes.go
+++ b/pkg/evs/services/volumes.go
@@ -76,23 +76,6 @@ func CheckVolumeExists(credentials *config.CloudCredentials, name string, sizeGB
 	return nil, nil
 }
 
-func GetVolumeDevicePath(c *config.CloudCredentials, id string) (string, error) {
-	volume, err := GetVolume(c, id)
-	log.V(4).Infof("[DEBUG] Got volume details: %#v", volume)
-
-	if err != nil {
-		if common.IsNotFound(err) {
-			return "", status.Errorf(codes.NotFound, "Volume %s does not exist, get device path failed", id)
-		}
-		return "", status.Error(codes.Internal, fmt.Sprintf("Querying volume details fails with error %s", err))
-	}
-	// shared disk will not be used and will only have an attachment if mounted.
-	if len(volume.Attachments) > 0 {
-		return volume.Attachments[0].Device, nil
-	}
-	return "", status.Error(codes.Internal, "Get volume device path failed, volume has no attachment")
-}
-
 func ExpandVolume(c *config.CloudCredentials, id string, newSize int) error {
 	client, err := getEvsV21Client(c)
 	if err != nil {

--- a/pkg/utils/mounts/mount.go
+++ b/pkg/utils/mounts/mount.go
@@ -157,6 +157,8 @@ func (m *Mount) getDevicePathBySerialID(volumeID string) string {
 		fmt.Sprintf("scsi-0QEMU_QEMU_HARDDISK_%s", volumeID[:20]),
 		// KVM virtio-scsi #852
 		fmt.Sprintf("scsi-0QEMU_QEMU_HARDDISK_%s", volumeID),
+		// KVM scsi
+		fmt.Sprintf("scsi-3%s", volumeID),
 		// ESXi
 		fmt.Sprintf("wwn-0x%s", strings.Replace(volumeID, "-", "", -1)),
 	}


### PR DESCRIPTION
### Test
```
====== Start Test EVS(normal) 
storageclass.storage.k8s.io/evs-sc created
persistentvolumeclaim/evs-normal-pvc created
pod/test-evs-normal-nginx created
pod "test-evs-normal-nginx" deleted
persistentvolumeclaim "evs-normal-pvc" deleted
storageclass.storage.k8s.io "evs-sc" deleted
------ PASS: EVS(normal) Test

======== Start Test EVS(block)
storageclass.storage.k8s.io/evs-sc created
persistentvolumeclaim/evs-block-pvc created
pod/test-evs-block-nginx created
pod "test-evs-block-nginx" deleted
persistentvolumeclaim "evs-block-pvc" deleted
storageclass.storage.k8s.io "evs-sc" deleted
------ PASS: EVS Test(block)

====== Start Test EVS(ephemeral) 
storageclass.storage.k8s.io/scratch-storage-class created
pod/ephemeral-example-nginx created
pod "ephemeral-example-nginx" deleted
storageclass.storage.k8s.io "scratch-storage-class" deleted
------ PASS: EVS(ephemeral) Test

====== Start Test EVS(topology) 
storageclass.storage.k8s.io/topology-evs-sc created
persistentvolumeclaim/evs-topology-pvc created
pod/test-evs-topology-nginx created
pod "test-evs-topology-nginx" deleted
persistentvolumeclaim "evs-topology-pvc" deleted
storageclass.storage.k8s.io "topology-evs-sc" deleted
------ PASS: EVS(topology) Test

====== Start Test EVS(resize) 
storageclass.storage.k8s.io/evs-sc created
persistentvolumeclaim/evs-normal-resize-pvc created
pod/test-evs-resize-nginx created
persistentvolumeclaim/evs-normal-resize-pvc configured
pod "test-evs-resize-nginx" deleted
persistentvolumeclaim "evs-normal-resize-pvc" deleted
storageclass.storage.k8s.io "evs-sc" deleted
------ PASS: EVS(resize) Test
```