### PR TITLE
modify the image version to the latest: v0.1.1

### DIFF
--- a/deploy/evs-csi-plugin/kubernetes/csi-evs-controller.yaml
+++ b/deploy/evs-csi-plugin/kubernetes/csi-evs-controller.yaml
@@ -90,7 +90,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: evs-csi-provisioner
-          image: swr.cn-north-4.myhuaweicloud.com/k8s-csi/evs-csi-plugin:v0.1.0
+          image: swr.cn-north-4.myhuaweicloud.com/k8s-csi/evs-csi-plugin:v0.1.1
           args:
             - /bin/evs-csi-plugin
             - "-v=5"

--- a/deploy/evs-csi-plugin/kubernetes/csi-evs-node.yaml
+++ b/deploy/evs-csi-plugin/kubernetes/csi-evs-node.yaml
@@ -47,7 +47,7 @@ spec:
         - name: evs-csi-plugin
           securityContext:
             privileged: true
-          image: swr.cn-north-4.myhuaweicloud.com/k8s-csi/evs-csi-plugin:v0.1.0
+          image: swr.cn-north-4.myhuaweicloud.com/k8s-csi/evs-csi-plugin:v0.1.1
           args:
             - /bin/evs-csi-plugin
             - "--v=5"


### PR DESCRIPTION
- As a new version has been released, modify the image version to the latest: v0.1.1
- Change the line separator to LR.

### Test
```
======== Start Test EVS(block)
storageclass.storage.k8s.io/evs-sc created
persistentvolumeclaim/evs-block-pvc created
pod/test-evs-block-nginx created
pod "test-evs-block-nginx" deleted
persistentvolumeclaim "evs-block-pvc" deleted
storageclass.storage.k8s.io "evs-sc" deleted
------ PASS: EVS Test(block)

====== Start Test EVS(normal) 
storageclass.storage.k8s.io/evs-sc created
persistentvolumeclaim/evs-normal-pvc created
pod/test-evs-normal-nginx created
pod "test-evs-normal-nginx" deleted
persistentvolumeclaim "evs-normal-pvc" deleted
storageclass.storage.k8s.io "evs-sc" deleted
------ PASS: EVS(normal) Test

====== Start Test EVS(topology) 
storageclass.storage.k8s.io/topology-evs-sc created
persistentvolumeclaim/evs-topology-pvc created
pod/test-evs-topology-nginx created
pod "test-evs-topology-nginx" deleted
persistentvolumeclaim "evs-topology-pvc" deleted
storageclass.storage.k8s.io "topology-evs-sc" deleted
------ PASS: EVS(topology) Test

====== Start Test EVS(resize) 
storageclass.storage.k8s.io/evs-sc created
persistentvolumeclaim/evs-normal-resize-pvc created
pod/test-evs-resize-nginx created
persistentvolumeclaim/evs-normal-resize-pvc configured
pod "test-evs-resize-nginx" deleted
persistentvolumeclaim "evs-normal-resize-pvc" deleted
storageclass.storage.k8s.io "evs-sc" deleted
------ PASS: EVS(resize) Test
```