### PR TITLE
feat: add sfs turbo nodeserver api

### DIFF
--- a/cmd/sfsturbo-csi-plugin/main.go
+++ b/cmd/sfsturbo-csi-plugin/main.go
@@ -28,12 +28,11 @@ import (
 	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/utils/mounts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 var (
 	endpoint    string
-	nodeID      string
 	cloudconfig string
 )
 
@@ -71,7 +70,7 @@ func main() {
 			// Make this configurable when ther are more options.
 			defaultShareProto := "NFS"
 			klog.V(3).Infof("run sfs turbo csi driver")
-			d := sfsturbo.NewDriver(nodeID, endpoint, defaultShareProto, cloud)
+			d := sfsturbo.NewDriver(endpoint, defaultShareProto, cloud)
 			mount := mounts.GetMountProvider()
 			metadata := metadatas.GetMetadataProvider(metadatas.MetadataID)
 			d.SetupDriver(mount, metadata)
@@ -82,9 +81,6 @@ func main() {
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
 	cmd.PersistentFlags().StringVar(&endpoint, "endpoint", "unix://tmp/csi.sock", "CSI endpoint")
-
-	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "node id")
-	cmd.MarkPersistentFlagRequired("nodeid")
 
 	cmd.PersistentFlags().StringVar(&cloudconfig, "cloud-config", "", "CSI driver cloud config")
 	cmd.MarkPersistentFlagRequired("cloud-config")

--- a/deploy/sfsturbo-csi-plugin/kubernetes/csi-sfsturbo-controller.yaml
+++ b/deploy/sfsturbo-csi-plugin/kubernetes/csi-sfsturbo-controller.yaml
@@ -24,12 +24,14 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.4.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
           args:
             - "-v=5"
             - "--csi-address=$(ADDRESS)"
-            - "--enable-leader-election"
-            - "--leader-election-type=leases"
+            - "--timeout=10m"
+            - "--feature-gates=Topology=true"
+            - "--extra-create-metadata"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -37,10 +39,12 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
           args:
             - "-v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+            - "--leader-election=true"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -48,12 +52,11 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: sfsturbo-csi-plugin
-          image: zhenguo/sfsturbo-csi-plugin:latest
+          image: swr.cn-north-4.myhuaweicloud.com/k8s-csi/sfsturbo-csi-plugin:v0.1.0
           args:
-            - "--v=2"
+            - "--v=5"
             - "--logtostderr"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--nodeid=$(NODE_ID)"
             - "--cloud-config=$(CLOUD_CONFIG)"
           ports:
             - containerPort: 28888
@@ -81,12 +84,26 @@ spec:
               name: socket-dir
             - mountPath: /etc/sfsturbo/
               name: sfsturbo-config
+        - name: csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+            - "--handle-volume-inuse-error=false"
+            - "--leader-election=true"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
           imagePullPolicy: Always
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=28888
             - --v=5
           volumeMounts:
@@ -96,6 +113,5 @@ spec:
         - name: socket-dir
           emptyDir: {}
         - name: sfsturbo-config
-          hostPath:
-            path: /etc/sfsturbo/
-            type: Directory
+          secret:
+            secretName: cloud-config

--- a/deploy/sfsturbo-csi-plugin/kubernetes/csi-sfsturbo-node.yaml
+++ b/deploy/sfsturbo-csi-plugin/kubernetes/csi-sfsturbo-node.yaml
@@ -2,7 +2,7 @@
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
-  name: csi-sfsturbo-node
+  name: csi-sfsturbo-plugin
   namespace: kube-system
 spec:
   selector:
@@ -24,14 +24,14 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=28889
             - --v=5
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -51,12 +51,11 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: sfsturbo
-          image: zhenguo/sfsturbo-csi-plugin:latest
+          image: swr.cn-north-4.myhuaweicloud.com/k8s-csi/sfsturbo-csi-plugin:v0.1.0
           args:
-            - "--v=2"
+            - "--v=5"
             - "--logtostderr"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--nodeid=$(NODE_ID)"
             - "--cloud-config=$(CLOUD_CONFIG)"
           ports:
             - containerPort: 28889
@@ -102,8 +101,7 @@ spec:
             path: /var/lib/kubelet/plugins_registry/
             type: DirectoryOrCreate
           name: registration-dir
-        - hostPath:
-            path: /etc/sfsturbo/
-            type: Directory
+        - secret:
+            secretName: cloud-config
           name: sfsturbo-config
 ---

--- a/deploy/sfsturbo-csi-plugin/kubernetes/rbac-csi-sfsturbo-controller.yaml
+++ b/deploy/sfsturbo-csi-plugin/kubernetes/rbac-csi-sfsturbo-controller.yaml
@@ -10,7 +10,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: sfs-turbo-external-provisioner-role
+  name: sfsturbo-external-provisioner-role
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -86,4 +86,44 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: sfsturbo-external-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# External Resizer
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sfsturbo-csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sfsturbo-csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-sfsturbo-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: sfsturbo-csi-resizer-role
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/sfsturbo/controllerserver.go
+++ b/pkg/sfsturbo/controllerserver.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sfsturbo
 
 import (
-	"fmt"
 	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/config"
 	"reflect"
 	"strconv"
@@ -314,7 +313,7 @@ func (cs *controllerServer) ValidateVolumeCapabilities(_ context.Context, req *c
 	log.Infof("ValidateVolumeCapabilities called with request %v", protosanitizer.StripSecrets(*req))
 
 	reqVolCap := req.GetVolumeCapabilities()
-	if reqVolCap == nil || len(reqVolCap) == 0 {
+	if len(reqVolCap) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "Validation failed, Volume Capabilities cannot be empty")
 	}
 	volumeID := req.GetVolumeId()
@@ -354,7 +353,7 @@ func (cs *controllerServer) ValidateVolumeCapabilities(_ context.Context, req *c
 
 func (cs *controllerServer) GetCapacity(_ context.Context, _ *csi.GetCapacityRequest) (
 	*csi.GetCapacityResponse, error) {
-	return nil, status.Error(codes.Unimplemented, fmt.Sprintf("GetCapacity is not yet implemented"))
+	return nil, status.Errorf(codes.Unimplemented, "GetCapacity is not yet implemented")
 }
 
 func (cs *controllerServer) ControllerExpandVolume(_ context.Context, req *csi.ControllerExpandVolumeRequest) (

--- a/pkg/sfsturbo/identityserver.go
+++ b/pkg/sfsturbo/identityserver.go
@@ -21,14 +21,15 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type identityServer struct {
 	Driver *SfsTurboDriver
 }
 
-func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+func (ids *identityServer) GetPluginInfo(_ context.Context, _ *csi.GetPluginInfoRequest) (
+	*csi.GetPluginInfoResponse, error) {
 	klog.V(5).Infof("Using default GetPluginInfo")
 
 	if ids.Driver.name == "" {
@@ -45,13 +46,14 @@ func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPlugin
 	}, nil
 }
 
-func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+func (ids *identityServer) Probe(_ context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
 	klog.V(5).Infof("Probe() called with req %+v", req)
 	// Do some healthy check here.
 	return &csi.ProbeResponse{}, nil
 }
 
-func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+func (ids *identityServer) GetPluginCapabilities(_ context.Context, req *csi.GetPluginCapabilitiesRequest) (
+	*csi.GetPluginCapabilitiesResponse, error) {
 	klog.V(5).Infof("GetPluginCapabilities called with req %+v", req)
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
@@ -73,13 +75,6 @@ func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.G
 				Type: &csi.PluginCapability_VolumeExpansion_{
 					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
 						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
-					},
-				},
-			},
-			{
-				Type: &csi.PluginCapability_VolumeExpansion_{
-					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
-						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
 					},
 				},
 			},

--- a/pkg/sfsturbo/server.go
+++ b/pkg/sfsturbo/server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/utils"
 
 	"google.golang.org/grpc"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
@@ -56,8 +56,6 @@ func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, c
 	s.wg.Add(1)
 
 	go s.serve(endpoint, ids, cs, ns)
-
-	return
 }
 
 func (s *nonBlockingGRPCServer) Wait() {
@@ -109,6 +107,6 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 
 	klog.Infof("Listening for connections on address: %#v", listener.Addr())
 
-	server.Serve(listener)
+	server.Serve(listener) //nolint:errcheck
 
 }


### PR DESCRIPTION
sfsturbo add nodeserver api feature and modify sfsturbo yaml file

====== Start Test SFS Turbo(dynamic)
storageclass.storage.k8s.io/sfsturbo-sc created
persistentvolumeclaim/sfsturbo-pvc-dynamic created
pod/sfsturbo-nginx-dynamic created
pod "sfsturbo-nginx-dynamic" deleted
persistentvolumeclaim "sfsturbo-pvc-dynamic" deleted
storageclass.storage.k8s.io "sfsturbo-sc" deleted
------ PASS: SFS Turbo(dynamic) Test

====== Start Test SFS Turbo(resize)
storageclass.storage.k8s.io/sfsturbo-sc created
persistentvolumeclaim/sfsturbo-pvc-resize created
pod/sfsturbo-nginx-resize created
persistentvolumeclaim/sfsturbo-pvc-resize configured
pod "sfsturbo-nginx-resize" deleted
persistentvolumeclaim "sfsturbo-pvc-resize" deleted
storageclass.storage.k8s.io "sfsturbo-sc" deleted
------ PASS: SFS Turbo(resize) Test