### PR TITLE
fix: sfs support get volume stats

### DIFF
--- a/cmd/sfs-csi-plugin/main.go
+++ b/cmd/sfs-csi-plugin/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/utils/mounts"
 	"os"
 
 	"github.com/huaweicloud/huaweicloud-csi-driver/pkg/config"
@@ -67,6 +68,8 @@ func main() {
 			// Make this configurable when ther are more options.
 			defaultShareProto := "NFS"
 			d := sfs.NewDriver(nodeID, endpoint, defaultShareProto, *cloud)
+			mount := mounts.GetMountProvider()
+			d.SetupDriver(mount)
 			d.Run()
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
/kind feature

**What this PR does / why we need it**:
This PR add an ability for sfs. User can use it to monitor volume capacity

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I have verified the volume capacity statistics function in the K8S cluster. The following is the verification result.

 NodeGetVolumeStats Information:
{
    "AvailableBytes":10737418240,
    "AvailableInodes":3708271302,
    "Block":false,
    "TotalBytes":10737418240,
    "TotalInodes":3932927999,
    "UsedBytes":0,
    "UsedInodes":224656697
}
SFS Detail Information from API: 
{
    "metadata":{
        "#sfstag#_sys_enterprise_project_id":"0",
        "enterprise_project_id":"0"
    },
    "size":10
}

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
