### PR TITLE
feat: add obs test shell

### DIFF
--- a/test/obs/dynamic.sh
+++ b/test/obs/dynamic.sh
@@ -1,0 +1,85 @@
+#! /bin/sh
+echo -e "====== Start Test OBS(dynamic) "
+
+testRes="false"
+
+cat << EOF | kubectl apply -f -
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: obs-sc
+provisioner: obs.csi.huaweicloud.com
+reclaimPolicy: Delete
+parameters:
+  acl: public-read-write
+EOF
+
+cat << EOF | kubectl apply -f -
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-obs
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: obs-sc
+EOF
+
+for (( i=0; i<4; i++));
+do
+    lines=`kubectl get pvc | grep pvc-obs | grep Bound | wc -l`
+    if [ "$lines" = "1" ]; then
+        testRes="true"
+        break
+    else
+        testRes="false"
+    fi
+    sleep 5
+done
+
+cat << EOF | kubectl create -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-obs
+spec:
+  containers:
+    - image: nginx
+      name: nginx-obs
+      command: ["/bin/sh"]
+      args: ["-c", "while true; do echo $(date -u) >> /mnt/obs/outfile; sleep 5; done"]
+      volumeMounts:
+        - mountPath: /mnt/obs
+          name: obs-data
+  volumes:
+    - name: obs-data
+      persistentVolumeClaim:
+        claimName: pvc-obs
+EOF
+
+for (( i=0; i<10; i++));
+do
+    lines=`kubectl get pod | grep nginx-obs | grep Running | wc -l`
+    if [ "$lines" = "1" ]; then
+        testRes="true"
+        break
+    else
+        testRes="false"
+    fi
+    sleep 10
+done
+
+kubectl delete pod nginx-obs
+kubectl delete pvc pvc-obs
+kubectl delete sc obs-sc
+
+if [ "$testRes" = "true" ]; then
+    echo -e "------ PASS: OBS(dynamic) Test\n"
+    exit 0
+else
+    echo -e "------ FAIL: OBS(dynamic) Test\n"
+    exit 1
+fi

--- a/test/obs/resize.sh
+++ b/test/obs/resize.sh
@@ -1,0 +1,124 @@
+#! /bin/sh
+echo -e "====== Start Test OBS(resize) "
+
+testRes="false"
+
+cat << EOF | kubectl apply -f -
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: obs-sc
+provisioner: obs.csi.huaweicloud.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  acl: public-read-write
+EOF
+
+cat << EOF | kubectl apply -f -
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-obs-resize
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: obs-sc
+EOF
+
+for (( i=0; i<4; i++));
+do
+    lines=`kubectl get pvc | grep pvc-obs-resize | grep Bound | wc -l`
+    if [ "$lines" = "1" ]; then
+        testRes="true"
+        break
+    else
+        testRes="false"
+    fi
+    sleep 5
+done
+
+cat << EOF | kubectl create -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-obs-resize
+spec:
+  containers:
+    - image: nginx
+      name: nginx-obs-resize
+      command: ["/bin/sh"]
+      args: ["-c", "while true; do echo $(date -u) >> /mnt/obs/outfile; sleep 5; done"]
+      volumeMounts:
+        - mountPath: /mnt/obs
+          name: obs-data
+  volumes:
+    - name: obs-data
+      persistentVolumeClaim:
+        claimName: pvc-obs-resize
+EOF
+
+for (( i=0; i<10; i++));
+do
+    lines=`kubectl get pod | grep nginx-obs-resize | grep Running | wc -l`
+    if [ "$lines" = "1" ]; then
+        testRes="true"
+        break
+    else
+        testRes="false"
+    fi
+    sleep 5
+done
+
+cat << EOF | kubectl apply -f -
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-obs-resize
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 60Gi
+  storageClassName: obs-sc
+EOF
+
+for (( i=0; i<4; i++));
+do
+    lines=`kubectl get pvc | grep pvc-obs-resize | grep Bound | wc -l`
+    if [ "$lines" = "1" ]; then
+        testRes="true"
+        break
+    else
+        testRes="false"
+    fi
+    sleep 5
+done
+
+for (( i=0; i<10; i++));
+do
+    lines=`kubectl get pod | grep nginx-obs-resize | grep Running | wc -l`
+    if [ "$lines" = "1" ]; then
+        testRes="true"
+        break
+    else
+        testRes="false"
+    fi
+    sleep 5
+done
+
+kubectl delete pod nginx-obs-resize
+kubectl delete pvc pvc-obs-resize
+kubectl delete sc obs-sc
+
+if [ "$testRes" = "true" ]; then
+    echo -e "------ PASS: OBS(resize) Test\n"
+    exit 0
+else
+    echo -e "------ FAIL: OBS(resize) Test\n"
+    exit 1
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

```
CentOS
k8s:1.20.0   docker:18.06.0
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc unchanged
persistentvolumeclaim/pvc-obs unchanged
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test



k8s:1.21.0  docker:20.10.2
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs created
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test


k8s:1.22.0  docker:20.10.2
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs created
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test


k8s:1.23.0  docker:20.10.2
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs created
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test

```

```
Ubuntu
k8s:1.20.15  docker:18.09.0
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc unchanged
persistentvolumeclaim/pvc-obs unchanged
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test



k8s:1.21.14   docker:20.10.7
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs created
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test


k8s:1.22.15   docker:20.10.7
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs created
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test


k8s:1.23.13   docker:20.10.7
====== Start Test OBS(dynamic) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs created
pod/nginx-obs created
pod "nginx-obs" deleted
persistentvolumeclaim "pvc-obs" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(dynamic) Test

====== Start Test OBS(resize) 
storageclass.storage.k8s.io/obs-sc created
persistentvolumeclaim/pvc-obs-resize created
pod/nginx-obs-resize created
persistentvolumeclaim/pvc-obs-resize configured
pod "nginx-obs-resize" deleted
persistentvolumeclaim "pvc-obs-resize" deleted
storageclass.storage.k8s.io "obs-sc" deleted
------ PASS: OBS(resize) Test

```



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
